### PR TITLE
nacos升级版本到2.3.0打开nacos鉴权

### DIFF
--- a/api/gateway/pom.xml
+++ b/api/gateway/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.2.0</version>
         <relativePath/>
     </parent>
     <groupId>cn.qihangerp</groupId>
@@ -18,8 +18,9 @@
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring-boot.version>3.0.2</spring-boot.version>
-        <spring-cloud-alibaba.version>2022.0.0.0</spring-cloud-alibaba.version>
+        <spring-boot.version>3.2.0</spring-boot.version>
+        <spring-cloud.version>2023.0.0</spring-cloud.version>
+        <spring-cloud-alibaba.version>2023.0.0.0-RC1</spring-cloud-alibaba.version>
     </properties>
 
     <dependencies>
@@ -41,12 +42,12 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-loadbalancer</artifactId>
-            <version>4.0.0</version>
+<!--            <version>4.0.0</version>-->
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-gateway</artifactId>
-            <version>4.0.0</version>
+<!--            <version>4.0.0</version>-->
         </dependency>
 <!--        <dependency>-->
 <!--            <groupId>org.springframework.cloud</groupId>-->
@@ -105,7 +106,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>2022.0.0</version> <!-- 对应你使用的Spring Cloud版本 -->
+                <version>${spring-cloud.version}</version> <!-- 对应你使用的Spring Cloud版本 -->
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/api/oms-api/pom.xml
+++ b/api/oms-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.2.0</version>
         <relativePath/>
     </parent>
 
@@ -19,8 +19,8 @@
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring-boot.version>3.0.2</spring-boot.version>
-        <spring-cloud-alibaba.version>2022.0.0.0</spring-cloud-alibaba.version>
+        <spring-boot.version>3.2.0</spring-boot.version>
+        <spring-cloud-alibaba.version>2023.0.0.0-RC1</spring-cloud-alibaba.version>
         <jwt.version>0.11.5</jwt.version>
     </properties>
 

--- a/api/open-api/pom.xml
+++ b/api/open-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.2.0</version>
         <relativePath/>
     </parent>
 
@@ -19,8 +19,8 @@
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring-boot.version>3.0.2</spring-boot.version>
-        <spring-cloud-alibaba.version>2022.0.0.0</spring-cloud-alibaba.version>
+        <spring-boot.version>3.2.0</spring-boot.version>
+        <spring-cloud-alibaba.version>2023.0.0.0-RC1</spring-cloud-alibaba.version>
         <jwt.version>0.11.5</jwt.version>
     </properties>
 

--- a/api/sys-api/pom.xml
+++ b/api/sys-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.2.0</version>
         <relativePath/>
     </parent>
     <groupId>cn.qihangerp.api</groupId>
@@ -19,8 +19,9 @@
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring-boot.version>3.0.2</spring-boot.version>
-        <spring-cloud-alibaba.version>2022.0.0.0</spring-cloud-alibaba.version>
+        <spring-boot.version>3.2.0</spring-boot.version>
+        <spring-cloud.version>2023.0.0</spring-cloud.version>
+        <spring-cloud-alibaba.version>2023.0.0.0-RC1</spring-cloud-alibaba.version>
         <jwt.version>0.11.5</jwt.version>
     </properties>
 
@@ -75,12 +76,12 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter</artifactId>
-            <version>4.0.0</version>
+<!--            <version>4.0.0</version>-->
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-loadbalancer</artifactId>
-            <version>4.0.0</version>
+<!--            <version>4.0.0</version>-->
         </dependency>
 <!--        <dependency>-->
 <!--            <groupId>org.springframework.cloud</groupId>-->
@@ -90,7 +91,7 @@
        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
-            <version>4.0.0</version>
+<!--            <version>4.0.0</version>-->
         </dependency>
 
         <dependency>
@@ -118,6 +119,19 @@
             <groupId>com.baomidou</groupId>
             <artifactId>mybatis-plus-boot-starter</artifactId>
             <version>3.5.5</version>
+<!--  启动报错 java.lang.IllegalArgumentException: Invalid value type for attribute 'factoryBeanObjectType': java.lang.String-->
+<!--  mybatis-spring 官方 ISSUE: https://github.com/mybatis/spring/issues/855  手动升级mybatis-spring到3.0.3-->
+            <exclusions>
+                <exclusion>
+                    <artifactId>mybatis-spring</artifactId>
+                    <groupId>org.mybatis</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.mybatis</groupId>
+            <artifactId>mybatis-spring</artifactId>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
@@ -205,6 +219,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version> <!-- 对应你使用的Spring Cloud版本 -->
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/core/common/src/main/java/cn/qihangerp/common/mq/MqUtils.java
+++ b/core/common/src/main/java/cn/qihangerp/common/mq/MqUtils.java
@@ -1,18 +1,18 @@
 package cn.qihangerp.common.mq;
 
 import lombok.AllArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 @AllArgsConstructor
 @Component
 public class MqUtils {
-    private final RedisTemplate redisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
 
     public void sendMessage(String channel, Object message) {
-        redisTemplate.convertAndSend(channel, message);
+        stringRedisTemplate.convertAndSend(channel, message);
     }
     public void sendApiMessage(MqMessage message) {
-        redisTemplate.convertAndSend("ApiMessage", message);
+        stringRedisTemplate.convertAndSend("ApiMessage", message);
     }
 }

--- a/module/open/pom.xml
+++ b/module/open/pom.xml
@@ -36,4 +36,16 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>10</source>
+                    <target>10</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/module/order/pom.xml
+++ b/module/order/pom.xml
@@ -37,4 +37,16 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>10</source>
+                    <target>10</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/module/stock/pom.xml
+++ b/module/stock/pom.xml
@@ -38,4 +38,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>10</source>
+                    <target>10</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring-boot.version>3.0.2</spring-boot.version>
-    <spring-cloud.version>2022.0.0</spring-cloud.version>
-    <spring-cloud-alibaba.version>2022.0.0.0</spring-cloud-alibaba.version>
+    <spring-boot.version>3.2.0</spring-boot.version>
+    <spring-cloud.version>2023.0.0</spring-cloud.version>
+    <spring-cloud-alibaba.version>2023.0.0.0-RC1</spring-cloud-alibaba.version>
     <jwt.version>0.11.5</jwt.version>
   </properties>
 


### PR DESCRIPTION
#Nacos2.2.0以后默认禁用nacos账户 需要新建账号
对应版本升级
spring-cloud 2023.0.0
spring-boot 3.2.0
spring-cloud-alibaba 2023.0.0.0-RC1
修改冲突
MqUtils中更改为StringRedisTemplate
sys-api中更改mybatis-spring版本号到3.0.3